### PR TITLE
Stats table & short link expiry column

### DIFF
--- a/.github/workflows/server-publish-image.yml
+++ b/.github/workflows/server-publish-image.yml
@@ -1,6 +1,8 @@
 name: 'Server: Publish Docker Image'
 
 on:
+  release:
+      types: [published]
   push:
     branches:
       - 'master'
@@ -57,9 +59,9 @@ jobs:
         ARGS: ${{ matrix.plan.resolver }}
       working-directory: server
 
-    - name: Tag name
-      id: tag_name
-      run: echo ::set-env name=TAG_NAME::$(echo $(cat package.yaml | grep version | sed -e 's/ //g' | cut -d ':' -f 2))
+    - name: Get release version
+      id: get_version
+      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
 
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
@@ -70,6 +72,6 @@ jobs:
         username: gillchristian
         password: ${{ secrets.docker_password }}
         workdir: server
-        tags: "latest,${{ env.TAG_NAME }}"
+        tags: "latest,${{ env.RELEASE_VERSION }}"
         context: .
         buildargs: BINARY_PATH

--- a/server/database/migrations/00002.visited.sql
+++ b/server/database/migrations/00002.visited.sql
@@ -1,0 +1,25 @@
+alter table if exists shortened
+  add column if not exists created_at timestamp not null default now(),
+  add column if not exists last_visit timestamp not null default now(),
+  add column if not exists expires boolean not null default TRUE;
+
+update shortened set expires = FALSE;
+
+create table if not exists stats (
+  id serial primary key,
+  links_created int,
+  links_visited int,
+  created_on_client int,
+  created_on_plugin int,
+  created_on_api int,
+  created_on_other int
+);
+
+insert into stats (
+  links_created,
+  links_visited,
+  created_on_client,
+  created_on_plugin,
+  created_on_api,
+  created_on_other
+) select count(*), sum(visits), 0, 0, 0, count(*) from shortened;

--- a/server/src/Api/Short/Models.hs
+++ b/server/src/Api/Short/Models.hs
@@ -15,6 +15,7 @@ module Api.Short.Models
     CreateResponse (..),
     ShortenedUrl (..),
     Stats (..),
+    CreatedOn (..),
   )
 where
 
@@ -28,11 +29,25 @@ import Text.Casing (camel)
 import Prelude
 
 -- -- Models ---
+data CreatedOn
+  = Client
+  | Plugin
+  | Api
+  | Other
+  deriving stock (Generic, Show)
+
+instance Json.ToJSON CreatedOn where
+  toJSON = Json.genericToJSON camelTags
+
+instance Json.FromJSON CreatedOn where
+  parseJSON = Json.genericParseJSON camelTags
 
 data CreateBody
   = CreateBody
       { createUrl :: Text,
-        createShort :: Maybe Text
+        createShort :: Maybe Text,
+        createExpires :: Maybe Bool,
+        createCreatedOn :: Maybe CreatedOn
       }
   deriving stock (Generic, Show)
 
@@ -58,7 +73,8 @@ data ShortenedUrl
   = ShortenedUrl
       { shortenedShort :: Text,
         shortenedUrl :: Text,
-        shortenedVisits :: Int
+        shortenedVisits :: Int,
+        shortenedExpires :: Bool
       }
   deriving stock (Generic, Show)
   deriving (FromRow)
@@ -89,9 +105,9 @@ dropLabelPrefix :: String -> Json.Options
 dropLabelPrefix prefix =
   Json.defaultOptions {Json.fieldLabelModifier = camel . stripPrefix prefix}
 
--- camelTags :: Json.Options
--- camelTags =
---   Json.defaultOptions {Json.constructorTagModifier = camel}
+camelTags :: Json.Options
+camelTags =
+  Json.defaultOptions {Json.constructorTagModifier = camel}
 
 stripPrefix :: Eq a => [a] -> [a] -> [a]
 stripPrefix prefix str = Maybe.fromMaybe str $ List.stripPrefix prefix str

--- a/server/src/Api/Short/Persistence.hs
+++ b/server/src/Api/Short/Persistence.hs
@@ -17,6 +17,8 @@ module Api.Short.Persistence
     nextShortRefCounter,
     insertUrl,
     urlsStats,
+    incLinksCreated,
+    incLinksVisited,
   )
 where
 
@@ -26,29 +28,29 @@ import Control.Monad (void)
 import Control.Monad.IO.Class (MonadIO)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import Database (execDb1, runDb1, runDb1_, runDbN_)
+import Database (execDb1, execDb1_, runDb1, runDb1_, runDbN_)
 import Database.PostgreSQL.Simple (Only (..))
 import Prelude
 
 findAllUrls :: MonadIO m => AppT m [ShortenedUrl]
-findAllUrls = runDbN_ "select short,url,visits from shortened"
+findAllUrls = runDbN_ "select short,url,visits from shortened" -- TODO pagination
 
 findUrlByLong :: MonadIO m => Text -> AppT m (Maybe ShortenedUrl)
 findUrlByLong url =
-  runDb1 "select short,url,visits from shortened where url = ?" (Only url)
+  runDb1 "select short,url,visits,expires from shortened where url = ?" (Only url)
 
 findUrlByShortToVisit :: MonadIO m => Text -> AppT m (Maybe ShortenedUrl)
 findUrlByShortToVisit short =
   runDb1
-    "update shortened set visits = visits + 1 where short = ? returning short,url,visits"
+    "update shortened set visits = visits + 1, last_visit = now() where short = ? returning short,url,visits,expires"
     (Only short)
 
 insertUrl :: MonadIO m => ShortenedUrl -> AppT m ()
 insertUrl ShortenedUrl {..} =
   void $
     execDb1
-      "insert into shortened (short,url) values (?,?)"
-      (shortenedShort, shortenedUrl)
+      "insert into shortened (short,url,expires) values (?,?,?)"
+      (shortenedShort, shortenedUrl, shortenedExpires)
 
 nextShortRefCounter :: MonadIO m => AppT m (Maybe Int)
 nextShortRefCounter =
@@ -57,5 +59,19 @@ nextShortRefCounter =
 
 urlsStats :: MonadIO m => AppT m Stats
 urlsStats =
-  -- TODO: use a separate table instead
-  fromMaybe (Stats 0 0) <$> runDb1_ "select count(*), sum(visits) from shortened"
+  fromMaybe (Stats 0 0)
+    <$> runDb1_ "select links_created,links_visited from stats where id = 1"
+
+incLinksCreated :: MonadIO m => CreatedOn -> AppT m ()
+incLinksCreated Client =
+  void $ execDb1_ "update stats set links_created = links_created + 1, created_on_client = created_on_client + 1 where id = 1"
+incLinksCreated Plugin =
+  void $ execDb1_ "update stats set links_created = links_created + 1, created_on_plugin = created_on_plugin + 1 where id = 1"
+incLinksCreated Api =
+  void $ execDb1_ "update stats set links_created = links_created + 1, created_on_api = created_on_api + 1 where id = 1"
+incLinksCreated Other =
+  void $ execDb1_ "update stats set links_created = links_created + 1, created_on_other = created_on_other + 1 where id = 1"
+
+incLinksVisited :: MonadIO m => AppT m ()
+incLinksVisited =
+  void $ execDb1_ "update stats set links_visited = links_visited + 1 where id = 1"

--- a/server/src/Database.hs
+++ b/server/src/Database.hs
@@ -7,6 +7,7 @@ module Database
     runDbN_,
     runDbN,
     execDb1,
+    execDb1_,
   )
 where
 
@@ -52,3 +53,8 @@ execDb1 :: (MonadReader Config m, MonadIO m, PG.ToRow b) => PG.Query -> b -> m I
 execDb1 query args = do
   pool <- asks configPool
   liftIO $ Pool.withResource pool (\con -> PG.execute con query args)
+
+execDb1_ :: (MonadReader Config m, MonadIO m) => PG.Query -> m Int64
+execDb1_ query = do
+  pool <- asks configPool
+  liftIO $ Pool.withResource pool (`PG.execute_` query)


### PR DESCRIPTION
This PR adds:

- build image on release instead of push to master
- add stats table (instead of querying shorts table)
- add expires column (to be used as a way to delete short links)