### PR TITLE
Some fixes & refactor

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -77,7 +77,7 @@ const App: React.FC = () => {
   }, [])
 
   const onLinkDelete = React.useCallback((url: string, links: string[]) => {
-    const linksFiltered = links.filter(link => link !== url)
+    const linksFiltered = links.filter(link => !link.includes(url))
     localStorage.set(linksLocalStorageKey, linksFiltered)
     setLinks(linksFiltered)
   }, [])

--- a/client/src/components/ClearInput.tsx
+++ b/client/src/components/ClearInput.tsx
@@ -1,0 +1,25 @@
+/** @jsx jsx */
+import * as React from 'react'
+import { css, jsx } from '@emotion/core'
+import { Palette } from '../constants'
+
+const styles = {
+  clearInput: css`
+    margin-left: 10px;
+    cursor: pointer;
+    font-size: 18px;
+    color: ${Palette.shade3};
+  `,
+}
+
+interface Props {
+  onClear: () => void
+}
+
+const ClearInput: React.FC<Props> = ({ onClear }) => (
+  <span css={styles.clearInput} role="button" onClick={onClear}>
+    🅧
+  </span>
+)
+
+export default ClearInput

--- a/client/src/components/CustomLinkString.tsx
+++ b/client/src/components/CustomLinkString.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import { css, jsx } from '@emotion/core'
 import { Palette } from '../constants'
+import ClearInput from './ClearInput'
 
 const styles = {
   container: css`
@@ -24,7 +25,6 @@ const styles = {
   `,
   content: css`
     width: 100%;
-    transition: width 0.3s ease;
     display: flex;
     align-items: center;
     border-bottom: 2px solid ${Palette.secondary};
@@ -32,12 +32,6 @@ const styles = {
   `,
   label: css`
     font-size: 20px;
-  `,
-  inputContainer: css`
-    overflow: hidden;
-    transition: width 0.3s ease;
-    position: relative;
-    top: 1px;
   `,
   input: css`
     border: none;
@@ -59,25 +53,29 @@ const CustomLinkString: React.FC<Props> = ({ customLink, setCustomLink }) => {
 
   return (
     <div css={styles.container}>
-      {!customLinkMode && (
+      {customLinkMode ? (
+        <React.Fragment>
+          <div css={styles.content}>
+            <div css={styles.label}>tsplay.dev/</div>
+            <input
+              css={styles.input}
+              placeholder="my-ts-example"
+              value={customLink}
+              onChange={e => setCustomLink(e.target.value)}
+            />
+          </div>
+          <ClearInput
+            onClear={() => {
+              setCustomLinkMode(false)
+              setCustomLink('')
+            }}
+          />
+        </React.Fragment>
+      ) : (
         <div css={styles.trigger} role="button" onClick={() => setCustomLinkMode(!customLinkMode)}>
           Customize link back-half
         </div>
       )}
-      <div
-        css={css`
-          ${styles.content};
-          width: ${customLinkMode ? '100%' : '0px'};
-        `}
-      >
-        <div css={styles.label}>tsplay.dev/</div>
-        <input
-          css={styles.input}
-          placeholder="my-ts-example"
-          value={customLink}
-          onChange={e => setCustomLink(e.target.value)}
-        />
-      </div>
     </div>
   )
 }

--- a/client/src/components/CustomLinkString.tsx
+++ b/client/src/components/CustomLinkString.tsx
@@ -2,7 +2,9 @@
 import * as React from 'react'
 import { css, jsx } from '@emotion/core'
 import { Palette } from '../constants'
-import ClearInput from './ClearInput'
+import wait from '../utils/wait'
+
+const ANIMATION_TIME = 350 // ms
 
 const styles = {
   container: css`
@@ -11,6 +13,8 @@ const styles = {
     font-size: 14px;
     display: flex;
     align-items: flex-end;
+    width: 96%;
+    position: relative;
   `,
   trigger: css`
     text-decoration: underline;
@@ -29,6 +33,8 @@ const styles = {
     align-items: center;
     border-bottom: 2px solid ${Palette.secondary};
     overflow: hidden;
+    transition: width ${ANIMATION_TIME}ms ease;
+    position: relative;
   `,
   label: css`
     font-size: 20px;
@@ -41,6 +47,14 @@ const styles = {
     font-size: 19px;
     line-height: 19px;
   `,
+  close: css`
+    cursor: pointer;
+    font-size: 22px;
+    color: ${Palette.shade3};
+    position: absolute;
+    right: -25px;
+    bottom: -2px;
+  `
 }
 
 interface Props {
@@ -50,31 +64,53 @@ interface Props {
 
 const CustomLinkString: React.FC<Props> = ({ customLink, setCustomLink }) => {
   const [customLinkMode, setCustomLinkMode] = React.useState(false)
+  const [showCloseLinkMode, setShowCloseLinkMode] = React.useState(false)
+  const [showToggleLinkMode, setShowToggleLinkMode] = React.useState(true)
 
   return (
     <div css={styles.container}>
-      {customLinkMode ? (
-        <React.Fragment>
-          <div css={styles.content}>
-            <div css={styles.label}>tsplay.dev/</div>
-            <input
-              css={styles.input}
-              placeholder="my-ts-example"
-              value={customLink}
-              onChange={e => setCustomLink(e.target.value)}
-            />
-          </div>
-          <ClearInput
-            onClear={() => {
-              setCustomLinkMode(false)
-              setCustomLink('')
-            }}
-          />
-        </React.Fragment>
-      ) : (
-        <div css={styles.trigger} role="button" onClick={() => setCustomLinkMode(!customLinkMode)}>
+      {showToggleLinkMode && (
+        <div
+          css={styles.trigger}
+          role="button"
+          onClick={async() => {
+            setShowToggleLinkMode(false)
+            setCustomLinkMode(!customLinkMode)
+            await wait(ANIMATION_TIME)
+            setShowCloseLinkMode(true)
+          }}
+        >
           Customize link back-half
         </div>
+      )}
+      <div
+        css={css`	
+          ${styles.content};	
+          width: ${customLinkMode ? '100%' : '0px'};
+        `}
+      >
+        <div css={styles.label}>tsplay.dev/</div>
+        <input
+          css={styles.input}
+          placeholder="my-ts-example"
+          value={customLink}
+          onChange={e => setCustomLink(e.target.value)}
+        />
+      </div>
+      {showCloseLinkMode && (
+        <span
+          css={styles.close}
+          role="button"
+          onClick={async () => {
+            setCustomLinkMode(false)
+            setCustomLink('')
+            setShowCloseLinkMode(false)
+            await wait(ANIMATION_TIME + 150)
+            setShowToggleLinkMode(true)
+          }}
+        >
+        X
+      </span>
       )}
     </div>
   )

--- a/client/src/components/LinkCreator.tsx
+++ b/client/src/components/LinkCreator.tsx
@@ -49,6 +49,8 @@ const styles = {
     border-radius: 0;
     margin: 0;
     padding-right: 40px;
+    position: relative;
+    right: 1px;
   `,
   button: css`
     height: ${CONTAINER_HEIGHT}px;

--- a/client/src/components/Links.tsx
+++ b/client/src/components/Links.tsx
@@ -104,6 +104,9 @@ const styles = {
     background: ${Palette.secondary};
     cursor: pointer;
     flex: 1;
+    transform: scale(.95);
+    position: relative;
+    left: 1px;
 
     @media (max-width: 550px) {
       img {

--- a/client/src/components/Links.tsx
+++ b/client/src/components/Links.tsx
@@ -8,6 +8,7 @@ import copyLogoSVG from '../assets/copy.svg'
 import { Palette } from '../constants'
 import { ShowToast } from '../hooks/useCopyClipboardToast'
 import { SCROLL_BAR_WIDTH } from '../styles/GlobalStyles'
+import { copyToClipboard } from '../utils/copyToClipboard'
 
 const styles = {
   wrapper: css`
@@ -98,7 +99,6 @@ const styles = {
     text-transform: uppercase;
     font-size: 15px;
     border: none;
-    outline: 0;
     padding: 7px 13px 5px 13px;
     height: ${CONTAINER_HEIGHT}px;
     background: ${Palette.secondary};
@@ -130,22 +130,6 @@ interface Props {
   onLinkDelete?: (url: string, links: string[]) => void
 }
 
-const copyToClipboard: (text: string, showToast: ShowToast) => void = async (text, showToast) => {
-  try {
-    await navigator.clipboard.writeText(text)
-    showToast(
-      <span>
-        <span role="img" aria-label="check mark" className="prevent-hue-rotate">
-          ✅
-        </span>
-        <strong css={styles.underline}>{text}</strong> copied to clipboard
-      </span>
-    )
-  } catch (e) {
-    showToast('⚠️ Sorry, there was an error trying to copy the link')
-  }
-}
-
 const Links: React.FC<Props> = ({ links, canDeleteItem, showToast, onLinkDelete }) => {
   const divRef = React.useRef<HTMLDivElement>(null)
   const [hasScroll, setHasScroll] = React.useState<boolean>(false)
@@ -159,35 +143,37 @@ const Links: React.FC<Props> = ({ links, canDeleteItem, showToast, onLinkDelete 
 
   return (
     <div css={styles.wrapper} className={canDeleteItem && hasScroll ? 'custom-scroll' : ''} ref={divRef}>
-      {links.map((link: string) => (
-        <div key={link} css={styles.container} className={canDeleteItem ? 'can-delete' : ''}>
-          <span
-            css={css`
-              ${styles.link};
-              ${hasScroll ? styles.linkWithScroll : ''}
-            `}
-          >
-            {link.replace('https://', '')}
-          </span>
-          <button
-            css={css`
-              ${styles.button};
-              ${hasScroll ? styles.buttonWithScroll : ''}
-            `}
-            onClick={() => copyToClipboard(link, showToast)}
-          >
-            <img alt="copy logo" src={copyLogoSVG} />
-          </button>
-          <span
-            role="button"
-            css={styles.close}
-            className="close-icon"
-            onClick={() => onLinkDelete && onLinkDelete(link, links)}
-          >
-            ⅹ
-          </span>
-        </div>
-      ))}
+      {links
+        .map(link => link.replace(/^https?:\/\//, ''))
+        .map((link: string) => (
+          <div key={link} css={styles.container} className={canDeleteItem ? 'can-delete' : ''}>
+            <span
+              css={css`
+                ${styles.link};
+                ${hasScroll ? styles.linkWithScroll : ''}
+              `}
+            >
+              {link}
+            </span>
+            <button
+              css={css`
+                ${styles.button};
+                ${hasScroll ? styles.buttonWithScroll : ''}
+              `}
+              onClick={() => copyToClipboard(link, showToast)}
+            >
+              <img alt="copy logo" src={copyLogoSVG} />
+            </button>
+            <span
+              role="button"
+              css={styles.close}
+              className="close-icon"
+              onClick={() => onLinkDelete && onLinkDelete(link, links)}
+            >
+              ⅹ
+            </span>
+          </div>
+        ))}
     </div>
   )
 }

--- a/client/src/styles/GlobalStyles.tsx
+++ b/client/src/styles/GlobalStyles.tsx
@@ -171,7 +171,6 @@ const GlobalStyles: React.FC = () => {
           top: 25px;
           font-size: 25px;
           cursor: pointer;
-          outline: none;
           user-select: none;
         `}
       >

--- a/client/src/utils/copyToClipboard.tsx
+++ b/client/src/utils/copyToClipboard.tsx
@@ -1,0 +1,27 @@
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core'
+
+import { ShowToast } from '../hooks/useCopyClipboardToast'
+
+const styles = {
+  underline: css`
+    text-decoration: underline;
+    margin-left: 5px;
+  `,
+}
+
+export const copyToClipboard: (text: string, showToast: ShowToast) => void = async (text, showToast) => {
+  try {
+    await navigator.clipboard.writeText(text)
+    showToast(
+      <span>
+        <span role="img" aria-label="check mark" className="prevent-hue-rotate">
+          ✅{' '}
+        </span>
+        <strong css={styles.underline}>{text}</strong> copied to clipboard
+      </span>
+    )
+  } catch (e) {
+    showToast('⚠️ Sorry, there was an error trying to copy the link')
+  }
+}

--- a/server/src/Api/Short.hs
+++ b/server/src/Api/Short.hs
@@ -94,10 +94,10 @@ isValidURL =
   (&&) <$> (URI.isURI . Text.unpack) <*> Text.isInfixOf "typescriptlang.org"
 
 shorterThan :: Int -> Text -> Bool
-shorterThan n = (<= n) . Text.length
+shorterThan n = (< n) . Text.length
 
 longerThan :: Int -> Text -> Bool
-longerThan n = (>= n) . Text.length
+longerThan n = (> n) . Text.length
 
 isValidChar :: Char -> Bool
 isValidChar =

--- a/server/src/Api/Short.hs
+++ b/server/src/Api/Short.hs
@@ -150,8 +150,8 @@ createHandler CreateBody {..} = do
 createWithCustomShort :: MonadIO m => Text -> Text -> Maybe CreatedOn -> Maybe Bool -> AppT m CreateResponse
 createWithCustomShort createUrl short createCreatedOn createExpires = do
   mbByShort <- findUrlByShort short
-  mbByLog <- findUrlByLong createUrl
-  case (mbByShort, mbByLog) of
+  mbByLong <- findUrlByLong createUrl
+  case (mbByShort, mbByLong) of
     (Nothing, Nothing) -> do
       Monad.void $ insertUrl $ ShortenedUrl short createUrl 0 (fromMaybe False createExpires)
       incLinksCreated $ fromMaybe Other createCreatedOn


### PR DESCRIPTION
- Create link function into hook
- Add 'clear custom link' button
- Clear custom link on link created
- Move copy to clipboard toast function to utils
- Fix copy to clipboard on creation (it was not copied before, only show toast)
- Add outline to inputs & buttons (for a11y, yeah we could do much more but _it's something_)
- Do not show `https?` on link copy toasts